### PR TITLE
raise Errno::* instead of RuntimeError

### DIFF
--- a/lib/ffi-xattr/error.rb
+++ b/lib/ffi-xattr/error.rb
@@ -8,14 +8,15 @@ class Xattr # :nodoc: all
 
     class << self
       def last
+        errno = FFI.errno
         ptr = FFI::MemoryPointer.new(:char, 256)
-        strerror_r(FFI.errno, ptr, 256)
+        strerror_r(errno, ptr, 256)
 
-        ptr.read_string
+        [ ptr.read_string, errno ]
       end
 
       def check(int)
-        raise last if int != 0
+        raise SystemCallError.new(*last) if int != 0
       end
     end
   end

--- a/spec/xattr_spec.rb
+++ b/spec/xattr_spec.rb
@@ -35,8 +35,11 @@ describe Xattr do
     xattr.list.should == []
   end
 
-  it "raises error when tries to remove inexistent attribute" do
-    lambda { xattr.remove("inexisting") }.should raise_error
+  it "raises Errno: when tries to remove inexistent attribute" do
+    lambda { xattr.remove("user.inexisting") }.should raise_error { |error|
+        error.should be_a(SystemCallError)
+        error.should respond_to(:errno)
+    }
   end
 
   it "returns nil if the attribute is not set" do


### PR DESCRIPTION
I need more granularity and visibility of errors for using extended attributes associated with FUSE filesystems.

I think this is the "right" behaviour but it is a change to the API since code that currently rescues RuntimeError will now need to rescue SystemCallError.

I have only got Linux to test with. I'm not able to test on Windows but reading the code would suggest that Windows errors behave differently anyway - eg get raises error on missing key, but remove does not.
